### PR TITLE
0.11.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: build-stitch-release
 
-on: 
+on:
   release:
     types: ["prereleased", "released"]
 
@@ -50,3 +50,20 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
           body: "Pre-Built Stitch"
+
+  publish-docs:
+    runs-on: windows-latest
+
+    steps:
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2
+        with:
+          node-version: '17'
+        run: npm install moonwave
+
+      - name: Deploy with gh-pages
+        run: |
+          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          npx moonwave build --publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 # Installation
 
 ### Method 1 (recommended) - Using [Wally](https://wally.run/) and [Rojo](https://rojo.space/)
-1. Add `Stitch = "sayhisam1/stitch@0.9.2"` under the [dependencies] section in `wally.toml`
+1. Add `Stitch = "sayhisam1/stitch@0.11.0"` under the [dependencies] section in `wally.toml`
 2. Use `wally install` to automatically download Stitch
 3. Update your [Rojo configuration](https://rojo.space/docs/6.x/project-format/) to point to the appropriate path and sync the file in.
 

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,4 +1,4 @@
 [tools]
-rojo = { source = "roblox/rojo", version = "7.0.0-rc.1" }
+rojo = { source = "roblox/rojo", version = "7.0.0-rc.3" }
 run-in-roblox = { source = "rojo-rbx/run-in-roblox", version = "0.3.0" }
 wally = { source = "UpliftGames/wally", version = "0.3.1" }

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,4 +1,4 @@
 [tools]
 rojo = { source = "roblox/rojo", version = "7.0.0-rc.1" }
 run-in-roblox = { source = "rojo-rbx/run-in-roblox", version = "0.3.0" }
-wally = { source = "UpliftGames/wally", version = "0.2.1" }
+wally = { source = "UpliftGames/wally", version = "0.3.1" }

--- a/src/Shared/Symbol.lua
+++ b/src/Shared/Symbol.lua
@@ -3,8 +3,7 @@ local Symbol = {
 }
 
 function Symbol.named(name)
-	Symbol._symbols[name] = Symbol._symbols[name] or {}
-
+	Symbol._symbols[name] = Symbol._symbols[name] or newproxy()
 	return Symbol._symbols[name]
 end
 

--- a/src/Shared/Util.lua
+++ b/src/Shared/Util.lua
@@ -50,9 +50,12 @@ function Util.getValues(dict, sizeEstimate: number?)
 	return values
 end
 
-function Util.mergeTable(a: {}, b: {})
+function Util.mergeTable(a: {}, b: {}, noneValue: any?)
 	local new_table = Util.shallowCopy(a)
 	for k, v in pairs(b) do
+		if v == noneValue then
+			v = nil
+		end
 		new_table[k] = v
 	end
 	return new_table

--- a/src/World/ComponentDefinition.lua
+++ b/src/World/ComponentDefinition.lua
@@ -1,5 +1,8 @@
 --!strict
 local Util = require(script.Parent.Parent.Shared.Util)
+local Symbol = require(script.Parent.Parent.Shared.Symbol)
+local NONE = Symbol.named("NONE")
+
 export type ComponentDefinition = {
 	name: string,
 	defaults: {}?,
@@ -85,7 +88,7 @@ ComponentDefinition.replicate = nil
 ComponentDefinition.destructor = nil
 
 function ComponentDefinition:createFromData(data: {}?): {}
-	data = Util.mergeTable(Util.deepCopy(self.defaults), data or {})
+	data = Util.mergeTable(Util.deepCopy(self.defaults), data or {}, NONE)
 
 	self:validateOrErrorData(data)
 
@@ -101,7 +104,7 @@ function ComponentDefinition:setFromData(data: {}): {}
 end
 
 function ComponentDefinition:updateFromData(old: {}, new: {}): {}
-	local data = Util.mergeTable(old, new)
+	local data = Util.mergeTable(old, new, NONE)
 
 	self:validateOrErrorData(data)
 

--- a/src/World/EntityManager.spec.lua
+++ b/src/World/EntityManager.spec.lua
@@ -1,5 +1,7 @@
 local ComponentDefinition = require(script.Parent.ComponentDefinition)
 local EntityManager = require(script.Parent.EntityManager)
+local Symbol = require(script.Parent.Parent.Shared.Symbol)
+local NONE = Symbol.named("NONE")
 
 return function()
 	local entityManager
@@ -54,6 +56,21 @@ return function()
 				baz = "qux",
 			})
 			expect(data.foo).to.equal("bar")
+			expect(data.baz).to.equal("qux")
+		end)
+		it("should remove NONE keys", function()
+			local component = setmetatable({
+				name = "testComponent",
+				defaults = {
+					foo = "bar",
+				},
+			}, ComponentDefinition)
+
+			local data = entityManager:addComponent(component, testInstance, {
+				baz = "qux",
+				foo = NONE
+			})
+			expect(data.foo).to.never.be.ok()
 			expect(data.baz).to.equal("qux")
 		end)
 		it("should properly validate data", function()
@@ -319,6 +336,22 @@ return function()
 				baz = "qux",
 			})
 			expect(entityManager:getComponent(component, testInstance).foo).to.equal("bar")
+			expect(entityManager:getComponent(component, testInstance).baz).to.equal("qux")
+		end)
+		it("should update NONE keys", function()
+			local component = setmetatable({
+				name = "testComponent",
+				defaults = {
+					foo = "bar",
+				},
+			}, ComponentDefinition)
+
+			local data = entityManager:addComponent(component, testInstance)
+			entityManager:updateComponent(component, testInstance, {
+				baz = "qux",
+				foo = NONE
+			})
+			expect(entityManager:getComponent(component, testInstance).foo).to.never.be.ok()
 			expect(entityManager:getComponent(component, testInstance).baz).to.equal("qux")
 		end)
 		it("should properly validate data", function()

--- a/src/World/EntityQuery.lua
+++ b/src/World/EntityQuery.lua
@@ -54,7 +54,6 @@ function EntityQuery:forEach(callback: ({},...{}) -> nil)
 	local entities = self.world:getEntitiesWith(self.withComponents[1])
 	for _, entity in ipairs(entities) do
 		local obtainedComponents = table.create(#self.withComponents)
-		table.insert(obtainedComponents, self.world:getComponent(self.withComponents[1], entity))
 
 		local valid = true
 		for _, withComponent in ipairs(self.withComponents) do

--- a/src/World/EntityQuery.spec.lua
+++ b/src/World/EntityQuery.spec.lua
@@ -94,4 +94,20 @@ return function()
 			expect(table.find(gotEntities, testInstance4)).to.be.ok()
 		end)
 	end)
+	describe("EntityQuery:forEach", function()
+		it("should pass all components to callback", function()
+			world:addComponent(testComponent, testInstance, {
+				foo = "bar"
+			})
+			world:addComponent(testComponent2, testInstance, {
+				baz="qux"
+			})
+
+			local valid = nil
+			EntityQuery.new(world):all(testComponent, testComponent2):forEach(function(entity, c1, c2)
+				valid = (entity==testInstance) and (c1.foo == "bar") and (c2.baz == "qux")
+			end)
+			expect(valid).to.be.ok()
+		end)
+	end)
 end

--- a/src/World/init.lua
+++ b/src/World/init.lua
@@ -4,6 +4,7 @@ local ComponentRegistry = require(script.ComponentRegistry)
 local EntityManager = require(script.EntityManager)
 local SystemManager = require(script.SystemManager)
 local EntityQuery = require(script.EntityQuery)
+local Symbol = require(script.Parent.Shared.Symbol)
 
 --[=[
 	@class World
@@ -14,6 +15,19 @@ local EntityQuery = require(script.EntityQuery)
 ]=]
 local World = {}
 World.__index = World
+
+--[=[
+	@prop NONE UserData
+	@within World
+	Used to set keys to `nil` on `world:addComponent` or `world:updateComponent` calls.
+	```lua
+	world:updateComponent("someComponent", entity, {
+		foo = World.NONE
+	})
+	world:getComponent("someComponent", entity).foo -- is nil
+	```
+]=]
+World.NONE = Symbol.named("NONE")
 
 --[=[
 	Creates a new World.
@@ -27,7 +41,7 @@ function World.new(namespace: string)
 	local self = setmetatable({
 		namespace = namespace,
 		componentRegistry = ComponentRegistry.new(),
-		entityManager = EntityManager.new(namespace),
+		entityManager = EntityManager.new(),
 		systemGroups = {},
 	}, World)
 


### PR DESCRIPTION
Release Notes:

- World: Adds `World.NONE` for key deletion
- EntityQuery: Fixed bug where the first component in `:all()` was passed twice to `forEach` calls